### PR TITLE
Always using 16 as the number of DataDirectory entries in the PE header.

### DIFF
--- a/reflect/Reader/PEReader.cs
+++ b/reflect/Reader/PEReader.cs
@@ -98,6 +98,8 @@ namespace IKVM.Reflection.Reader
 		public const WORD IMAGE_SUBSYSTEM_WINDOWS_GUI = 2;
 		public const WORD IMAGE_SUBSYSTEM_WINDOWS_CUI = 3;
 
+		public const WORD IMAGE_NUMBEROF_DIRECTORY_ENTRIES = 16;
+
 		public WORD Magic;
 		public BYTE MajorLinkerVersion;
 		public BYTE MinorLinkerVersion;
@@ -183,8 +185,8 @@ namespace IKVM.Reflection.Reader
 			}
 			LoaderFlags = br.ReadUInt32();
 			NumberOfRvaAndSizes = br.ReadUInt32();
-			DataDirectory = new IMAGE_DATA_DIRECTORY[NumberOfRvaAndSizes];
-			for (uint i = 0; i < NumberOfRvaAndSizes; i++)
+			DataDirectory = new IMAGE_DATA_DIRECTORY[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+			for (uint i = 0; i < IMAGE_NUMBEROF_DIRECTORY_ENTRIES; i++)
 			{
 				DataDirectory[i] = new IMAGE_DATA_DIRECTORY();
 				DataDirectory[i].Read(br);


### PR DESCRIPTION
Using the value read into NumberOfRvaAndSizes can result in an assembly failing to load with IKVM.Reflection that loads successfully with System.Reflection on Microsoft's and Mono's implementation of .NET.

Inside Microsoft .NET IL Assembler p51 describes NumberOfRvaAndSizes as "Number of entries in the DataDirectory array; at least 16. Although it is theoretically possible to emit more than 16 data directories, all existing managed compilers emit exactly 16 data directories, with the sixteenth (last) data directory never used (reserved)." The implementation of Mono's System.Reflection assumes, and memcpy's, 16 DataDirectory entries when loading an assembly.
