### PR TITLE
Quoted public key tokens fail computation

### DIFF
--- a/reflect/Fusion.cs
+++ b/reflect/Fusion.cs
@@ -610,7 +610,7 @@ namespace IKVM.Reflection
 				publicKeyToken = null;
 				return false;
 			}
-			publicKeyToken = AssemblyName.ComputePublicKeyToken(str);
+			publicKeyToken = AssemblyName.ComputePublicKeyToken(str.Trim('"'));
 			return true;
 		}
 


### PR DESCRIPTION
We are finding some public key tokens coming through double-quoted and thus crashing the mono (mcs) compiler. This trims the any quoted identifiers so behaviour is as expected with MSBuild.
