### PR TITLE
Fix infinite loops.

### DIFF
--- a/reflect/Emit/ExceptionHandler.cs
+++ b/reflect/Emit/ExceptionHandler.cs
@@ -100,7 +100,7 @@ namespace IKVM.Reflection.Emit
 		public override bool Equals(object obj)
 		{
 			ExceptionHandler? other = obj as ExceptionHandler?;
-			return other != null && Equals(other);
+			return other != null && other.HasValue && Equals(other.Value);
 		}
 
 		public override int GetHashCode()

--- a/reflect/Emit/ModuleBuilder.cs
+++ b/reflect/Emit/ModuleBuilder.cs
@@ -140,7 +140,7 @@ namespace IKVM.Reflection.Emit
 			public override bool Equals(object obj)
 			{
 				MemberRefKey? other = obj as MemberRefKey?;
-				return other != null && Equals(other);
+				return other != null && other.HasValue && Equals(other.Value);
 			}
 
 			public override int GetHashCode()


### PR DESCRIPTION
In both cases, we were sending X? type, therefore automatically resolving
to X.Equals(object), instead of X.Equals(X).
