### PR TITLE
Use the current values of pack and size as the defaults when using a pseudo-custom layout

### DIFF
--- a/reflect/Emit/TypeBuilder.cs
+++ b/reflect/Emit/TypeBuilder.cs
@@ -571,8 +571,8 @@ namespace IKVM.Reflection.Emit
 			{
 				layout = (LayoutKind)val;
 			}
-			pack = (short)((int?)customBuilder.GetFieldValue("Pack") ?? 0);
-			size = (int?)customBuilder.GetFieldValue("Size") ?? 0;
+			pack = (short)((int?)customBuilder.GetFieldValue("Pack") ?? pack);
+			size = (int?)customBuilder.GetFieldValue("Size") ?? size;
 			CharSet charSet = customBuilder.GetFieldValue<CharSet>("CharSet") ?? CharSet.None;
 			attribs &= ~TypeAttributes.LayoutMask;
 			switch (layout)


### PR DESCRIPTION
Fixes #18941

We were wrongly setting these values to chosen defaults, and then overwriting them by applying the custom pack attributes, which lacked a size.