### PR TITLE
Fix MSBuild build with xbuild 12.0 engine (mono 4.2.1)

### DIFF
--- a/reflect/IKVM.Reflection.csproj
+++ b/reflect/IKVM.Reflection.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IKVM.Reflection</RootNamespace>
     <AssemblyName>IKVM.Reflection</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkSubset>
     </TargetFrameworkSubset>


### PR DESCRIPTION
(This is same PR as https://github.com/mono/ikvm-fork/pull/11 but cherry-picked to be merged to `master-signed` branch.)

If anyone tried to build IKVM.Reflection with the xbuild 12.0
engine that comes with mono 4.2.1 [1] (quite widespread given
that it's the version bundled with Ubuntu 16.04.x LTS), the
build would not work.

This change similar to this recent commit in MonoAddins:
https://github.com/mono/mono-addins/commit/a3efa4ca9f56fab3aae32060b3b56d3585505966

[1] $ mono --version
Mono JIT compiler version 4.2.1 (Debian 4.2.1.102+dfsg2-7ubuntu4)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           __thread
	SIGSEGV:       altstack
	Notifications: epoll
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug
	LLVM:          supported, not enabled.
	GC:            sgen