### PR TITLE
[reflect] fix more usage of SHA1Managed for FIPS

### DIFF
--- a/reflect/Emit/AssemblyBuilder.cs
+++ b/reflect/Emit/AssemblyBuilder.cs
@@ -472,21 +472,23 @@ namespace IKVM.Reflection.Emit
 
 		private int AddFile(ModuleBuilder manifestModule, string fileName, int flags)
 		{
-			SHA1Managed hash = new SHA1Managed();
-			string fullPath = fileName;
-			if (dir != null)
+			using (var hash = SHA1.Create())
 			{
-				fullPath = Path.Combine(dir, fileName);
-			}
-			using (FileStream fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read))
-			{
-				using (CryptoStream cs = new CryptoStream(Stream.Null, hash, CryptoStreamMode.Write))
+				string fullPath = fileName;
+				if (dir != null)
 				{
-					byte[] buf = new byte[8192];
-					ModuleWriter.HashChunk(fs, cs, buf, (int)fs.Length);
+					fullPath = Path.Combine(dir, fileName);
 				}
+				using (FileStream fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read))
+				{
+					using (CryptoStream cs = new CryptoStream(Stream.Null, hash, CryptoStreamMode.Write))
+					{
+						byte[] buf = new byte[8192];
+						ModuleWriter.HashChunk(fs, cs, buf, (int)fs.Length);
+					}
+				}
+				return manifestModule.__AddModule(flags, Path.GetFileName(fileName), hash.Hash);
 			}
-			return manifestModule.__AddModule(flags, Path.GetFileName(fileName), hash.Hash);
 		}
 
 		public void AddResourceFile(string name, string fileName)


### PR DESCRIPTION
In e9946684, I fixed the usage of `SHA1Managed` that I found from a stack trace while running `mkbundle.exe` on Windows.

I found 3 more usages that needed to be fixed.