### PR TITLE
Refactor code to fix an IndexOutOfRangeException.

### DIFF
--- a/reflect/Metadata/Tables.cs
+++ b/reflect/Metadata/Tables.cs
@@ -450,20 +450,21 @@ namespace IKVM.Reflection.Metadata
 				{
 					return new Enumerator(records, table.RowCount - 1, -1, token);
 				}
-				int index = BinarySearch(records, table.RowCount, token & 0xFFFFFF);
+				var maskedToken = token & 0xFFFFFF;
+				int index = BinarySearch(records, table.RowCount, maskedToken);
 
 				if (index < 0)
 				{
 					return new Enumerator(null, 0, 1, -1);
 				}
 				int start = index;
-				while (start > 0 && (((records [start - 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF)) || ((records [start - 1].FilterKey & 0xFFFFFF) == 0)))
+				while (start > 0 && (((records [start - 1].FilterKey & 0xFFFFFF) == maskedToken) || ((records [start - 1].FilterKey & 0xFFFFFF) == 0)))
 				{
 					start--;
 				}
 				int end = index;
 				int max = table.RowCount - 1;
-				while (end < max && (((records [end + 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF)) || ((records [end + 1].FilterKey & 0xFFFFFF) == 0)))
+				while (end < max && (((records [end + 1].FilterKey & 0xFFFFFF) == maskedToken) || ((records [end + 1].FilterKey & 0xFFFFFF) == 0)))
 				{
 					end++;
 				}

--- a/reflect/Metadata/Tables.cs
+++ b/reflect/Metadata/Tables.cs
@@ -458,14 +458,20 @@ namespace IKVM.Reflection.Metadata
 					return new Enumerator(null, 0, 1, -1);
 				}
 				int start = index;
-				while (start > 0 && (((records [start - 1].FilterKey & 0xFFFFFF) == maskedToken) || ((records [start - 1].FilterKey & 0xFFFFFF) == 0)))
+				while (start > 0)
 				{
+					var maskedFilterKey = records [start - 1].FilterKey & 0xFFFFFF;
+					if (maskedFilterKey != maskedToken && maskedFilterKey != 0)
+						break;
 					start--;
 				}
 				int end = index;
 				int max = table.RowCount - 1;
-				while (end < max && (((records [end + 1].FilterKey & 0xFFFFFF) == maskedToken) || ((records [end + 1].FilterKey & 0xFFFFFF) == 0)))
+				while (end < max)
 				{
+					var maskedFilterKey = records [end + 1].FilterKey & 0xFFFFFF;
+					if (maskedFilterKey != maskedToken && maskedFilterKey != 0)
+						break;
 					end++;
 				}
 				return new Enumerator(records, end, start - 1, token);

--- a/reflect/Metadata/Tables.cs
+++ b/reflect/Metadata/Tables.cs
@@ -457,13 +457,13 @@ namespace IKVM.Reflection.Metadata
 					return new Enumerator(null, 0, 1, -1);
 				}
 				int start = index;
-				while (start > 0 && (((records [start - 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF))) || ((records [start - 1].FilterKey & 0xFFFFFF) == 0))
+				while (start > 0 && (((records [start - 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF)) || ((records [start - 1].FilterKey & 0xFFFFFF) == 0)))
 				{
 					start--;
 				}
 				int end = index;
 				int max = table.RowCount - 1;
-				while (end < max && (((records [end + 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF))) || ((records [end + 1].FilterKey & 0xFFFFFF) == 0))
+				while (end < max && (((records [end + 1].FilterKey & 0xFFFFFF) == (token & 0xFFFFFF)) || ((records [end + 1].FilterKey & 0xFFFFFF) == 0)))
 				{
 					end++;
 				}


### PR DESCRIPTION
Refactor code to fix an IndexOutOfRangeException that occured because the
'start > 0' condition didn't protect the entire subsequent expression.

* Extract common expressions to reduce the number of parenthesis.
* Refactor code to reduce duplication (and more parenthesis).

Fixes https://github.com/mono/ikvm-fork/pull/20#issuecomment-702316695